### PR TITLE
Add github logo to website header

### DIFF
--- a/components/AppHeader.tsx
+++ b/components/AppHeader.tsx
@@ -3,7 +3,7 @@ import Link from 'next/link'
 import Image from 'next/image'
 import { usePathname } from 'next/navigation'
 import { Button } from '@/components/ui/button'
-import { User } from 'lucide-react'
+import { User, Github } from 'lucide-react'
 import * as React from 'react'
 
 export function AppHeader() {
@@ -32,8 +32,17 @@ export function AppHeader() {
           <Image src="/logo.png" alt="CatCV" width={1032} height={725} className="h-10 w-auto" priority />
           <span className="sr-only">CatCV</span>
         </Link>
-        <nav className="relative flex items-center gap-2">
+        <nav className="relative flex items-center gap-4">
           <Link href="/dashboard" className={pathname === '/dashboard' ? 'underline' : 'hover:underline'}>Dashboard</Link>
+          <Link 
+            href="https://github.com/Gurbeh/CatCV" 
+            target="_blank" 
+            rel="noopener noreferrer"
+            className="flex items-center justify-center p-2 rounded-md hover:bg-accent hover:text-accent-foreground transition-colors"
+            aria-label="View source code on GitHub"
+          >
+            <Github className="h-4 w-4" />
+          </Link>
           <div ref={menuRef} className="relative">
             <Button variant="ghost" size="icon" aria-label="Account menu" aria-expanded={open} aria-haspopup="menu" onClick={() => setOpen((v) => !v)}>
               <User className="h-4 w-4" />


### PR DESCRIPTION
## Summary
Adds a clickable GitHub logo to the website header, linking to the project's repository (`https://github.com/Gurbeh/CatCV`). The logo opens the link in a new tab and is styled consistently with the existing header elements.

## Test Plan
1. Navigate to the website.
2. Verify that a GitHub logo is visible in the header.
3. Click the GitHub logo and confirm it opens the project repository in a new browser tab.
4. Check that the logo's styling (size, hover effects, spacing) is consistent with other header elements.

## Checklist
- [ ] Passing CI/Status checks (Vercel, tests)
- [ ] No secrets committed
- [ ] Ready for review

---
<a href="https://cursor.com/background-agent?bcId=bc-87c658be-ab71-4d80-88e1-e822a02f73c9">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-87c658be-ab71-4d80-88e1-e822a02f73c9">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

