### PR TITLE
feat: show header skeleton while auth loads

### DIFF
--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -2,7 +2,6 @@ import type { Metadata } from 'next'
 import './globals.css'
 import { Providers } from '@/providers'
 import { SpeedInsights } from "@vercel/speed-insights/next"
-import { AppHeader } from '@/components/AppHeader'
 import { getAuthSession } from '@/lib/supabase/server'
 
 export const metadata: Metadata = {

--- a/components/AppHeader.tsx
+++ b/components/AppHeader.tsx
@@ -13,6 +13,7 @@ export function AppHeader() {
   const [open, setOpen] = React.useState(false)
   const email = useAuthStore((s) => s.user?.email ?? null)
   const isLoggedIn = useAuthStore((s) => s.isLoggedIn())
+  const isReady = useAuthStore((s) => s.isReady())
   const menuRef = React.useRef<HTMLDivElement | null>(null)
   React.useEffect(() => {
     function onDocClick(e: MouseEvent) {
@@ -37,35 +38,44 @@ export function AppHeader() {
           <span className="sr-only">CatCV</span>
         </Link>
         <nav className="relative flex items-center gap-2">
-          {isLoggedIn ? (
-            <Link href="/dashboard" className={pathname === '/dashboard' ? 'underline' : 'hover:underline'}>Dashboard</Link>
-          ) : null}
-          {isLoggedIn ? (
-            <div ref={menuRef} className="relative">
-              <Button variant="ghost" size="icon" aria-label="Account menu" aria-expanded={open} aria-haspopup="menu" onClick={() => setOpen((v) => !v)}>
-                <User className="h-4 w-4" />
-              </Button>
-              {open ? (
-                <div role="menu" className="absolute right-0 z-50 mt-2 w-48 rounded-md border bg-popover p-1 text-popover-foreground shadow-md">
-                  <div className="cursor-default select-none rounded-sm px-2 py-1.5 text-sm opacity-60">Signed in as {email}</div>
-                  <div className="-mx-1 my-1 h-px bg-border" />
-                  <form
-                    action={async () => {
-                      await signOutAction()
-                      window.location.href = '/'
-                    }}
-                  >
-                    <button className="w-full rounded-sm px-2 py-1.5 text-left text-sm hover:bg-accent">
-                      Sign out
-                    </button>
-                  </form>
-                </div>
+          {isReady ? (
+            <>
+              {isLoggedIn ? (
+                <Link href="/dashboard" className={pathname === '/dashboard' ? 'underline' : 'hover:underline'}>Dashboard</Link>
               ) : null}
-            </div>
+              {isLoggedIn ? (
+                <div ref={menuRef} className="relative">
+                  <Button variant="ghost" size="icon" aria-label="Account menu" aria-expanded={open} aria-haspopup="menu" onClick={() => setOpen((v) => !v)}>
+                    <User className="h-4 w-4" />
+                  </Button>
+                  {open ? (
+                    <div role="menu" className="absolute right-0 z-50 mt-2 w-48 rounded-md border bg-popover p-1 text-popover-foreground shadow-md">
+                      <div className="cursor-default select-none rounded-sm px-2 py-1.5 text-sm opacity-60">Signed in as {email}</div>
+                      <div className="-mx-1 my-1 h-px bg-border" />
+                      <form
+                        action={async () => {
+                          await signOutAction()
+                          window.location.href = '/'
+                        }}
+                      >
+                        <button className="w-full rounded-sm px-2 py-1.5 text-left text-sm hover:bg-accent">
+                          Sign out
+                        </button>
+                      </form>
+                    </div>
+                  ) : null}
+                </div>
+              ) : (
+                <div className="flex items-center gap-2">
+                  <Link href="/login" className={buttonClasses({ size: 'sm' })}>Login</Link>
+                  <Link href="/sign-up" className={buttonClasses({ variant: 'outline', size: 'sm' })}>Sign Up</Link>
+                </div>
+              )}
+            </>
           ) : (
             <div className="flex items-center gap-2">
-              <Link href="/login" className={buttonClasses({ size: 'sm'  })}>Login</Link>
-              <Link href="/sign-up" className={buttonClasses({ variant: 'outline', size: 'sm' })}>Sign Up</Link>
+              <div className="h-8 w-16 animate-pulse rounded bg-muted" />
+              <div className="h-8 w-20 animate-pulse rounded bg-muted" />
             </div>
           )}
         </nav>


### PR DESCRIPTION
## Summary
- show loading skeleton in header until AuthStore resolves
- drop unused AppHeader import in root layout

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_b_68be1068e770832c861ef609fe570d34